### PR TITLE
DEV: Using modern PHP features + fix README to v4 version

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,9 @@ The `Factory` class provides a simple wrapper for the validation functionality, 
 
 ```php
 use Dealroom\SocialsHelpers\Factory;
-use Dealroom\SocialsHelpers\Parser;
+use Dealroom\SocialsHelpers\Normalizers\TwitterNormalizer;
 
-$data = Factory::parseUrl('http://twitter.com/Dealroom', [Parser::PLATFORM_TWITTER])->getNormalizedUrl();
+$data = Factory::parseUrl('http://twitter.com/Dealroom', [TwitterNormalizer::getPlatform()])->getNormalizedUrl();
 
 echo $data;
 
@@ -38,9 +38,9 @@ Or if you want to extract social network ID (handle):
 
 ```php
 use Dealroom\SocialsHelpers\Factory;
-use Dealroom\SocialsHelpers\Parser;
+use Dealroom\SocialsHelpers\Normalizers\TwitterNormalizer;
 
-$data = Factory::parseUrl('https://twitter.com/dealroom', [Parser::PLATFORM_TWITTER])->getId();
+$data = Factory::parseUrl('https://twitter.com/dealroom', [TwitterNormalizer::getPlatform()])->getId();
 
 echo $data;
 
@@ -65,31 +65,22 @@ The following platforms are supported by default:
 ### Registering new platforms
 
 To register a new normalizer, you need to create a new class that implements
-the `NormalizerInterface` interface and add it to the `Factory` class.
+the `NormalizerInterface` interface (for example, by extending the `AbstractNormalizer` class).
+After that, you need to register the new normalizer in the `Factory` class.
 
 ```php
-use Dealroom\SocialsHelpers\Normalizers\NormalizerInterface;
+use Dealroom\SocialsHelpers\Normalizers\AbstractNormalizer;
+use Dealroom\SocialsHelpers\Normalizers\Factory;
+use Dealroom\SocialsHelpers\Factory;
 
-class CustomNormalizer implements NormalizerInterface
+class CustomNormalizer extends AbstractNormalizer
 {
     // Implement the interface methods
 }
-```
-
-Then add it to the `Factory` class
-
-```php
-use Dealroom\SocialsHelpers\Normalizers\Factory;
 
 Factory::addNormalizer(CustomNormalizer::class);
-```
 
-And now, you can use it
-
-```php
-use Dealroom\SocialsHelpers\Factory;
-
-$data = Factory::parseUrl('https://custom.com/Dealroom', [Parser::PLATFORM_CUSTOM])->getNormalizedUrl();
+$data = Factory::parseUrl('https://custom.com/Dealroom', [CustomNormalizer::getPlatform()])->getNormalizedUrl();
 ```
 
 ## Testing

--- a/src/Normalizers/AbstractNormalizer.php
+++ b/src/Normalizers/AbstractNormalizer.php
@@ -12,7 +12,6 @@ abstract class AbstractNormalizer implements NormalizerInterface
     protected string $pattern;
     protected string $normalizedUrl;
     protected int|array $idPosition;
-
     protected array $cleanUrlSettings = ['forceHTTPS' => true, 'forceLowerCase' => true];
 
     public function normalize(string $url): string

--- a/src/Result.php
+++ b/src/Result.php
@@ -7,18 +7,14 @@ namespace Dealroom\SocialsHelpers;
 use Dealroom\SocialsHelpers\Normalizers\Factory as NormalizerFactory;
 use Dealroom\SocialsHelpers\Normalizers\NormalizerInterface;
 
-class Result
+readonly class Result
 {
-    private string $platform;
-    private string $url;
     private string $normalizedUrl;
     private string $id;
     private NormalizerInterface $normalizer;
 
-    public function __construct(string $platform, string $url)
+    public function __construct(private string $platform, private string $url)
     {
-        $this->platform = $platform;
-        $this->url = $url;
         $this->normalizer = $this->getNormalizer();
         $this->normalizedUrl = $this->normalizer->normalize($this->url);
         $this->id = $this->normalizer->normalizeToId($this->url);


### PR DESCRIPTION
## What has been done
- Use slightly more modern PHP features to configure `Result` class
- Fix `README.md` examples as they been not fixed after moving to `v4`

## PR Checklist
- [x] My code follows the style guidelines of this project
- [x] I have made corresponding changes to the documentation
